### PR TITLE
added if condition to sentry_conf definition to allow use default sqlite...

### DIFF
--- a/definitions/sentry_conf.rb
+++ b/definitions/sentry_conf.rb
@@ -91,6 +91,8 @@ define :sentry_conf,
       end
     elsif db_options['ENGINE'] == 'django.db.backends.oracle'
       driver_name = 'cx_Oracle'
+    elsif db_options['ENGINE'] == 'django.db.backends.sqlite3'  # default handler
+      driver_name = 'pysqlite'
     else
       raise "You need specify database ENGINE"
     end


### PR DESCRIPTION
Current version doesn't work correctly when default database or any sqlite3 configuration is used
