### PR TITLE
replace node --> node.set, otherwise it breaks provision for Chef 11

### DIFF
--- a/recipes/nginx.rb
+++ b/recipes/nginx.rb
@@ -16,7 +16,7 @@ Chef::Log.info("Making nginx frontend for sentry service")
 ruby_block "setup-static-dir" do
   block do
     path = `#{node["sentry"]["virtualenv"]}/bin/python -c "import sentry, os; print(os.path.dirname(sentry.__file__));"`
-    node["sentry"]["static_dir"] = "#{path.strip()}/static/"
+    node.set["sentry"]["static_dir"] = "#{path.strip()}/static/"
   end
   action :create
 end


### PR DESCRIPTION
Chef 11 (and greater..won't be) environment doesn't allow such setters, need to set attributes from recipes explicitly.
