### PR TITLE
allow specifying a from user for emails and fallback to user

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -63,6 +63,7 @@ default["sentry"]["settings"]["social_auth_create_users"] = 'True'
 
 # Email settings
 default["sentry"]["settings"]["email"] = {
+  "from" => '',
   "backend" => 'django.core.mail.backends.smtp.EmailBackend',
   "host" => "localhost",
   "password" => '',

--- a/templates/default/sentry/sentry.conf.erb
+++ b/templates/default/sentry/sentry.conf.erb
@@ -43,7 +43,7 @@ SENTRY_KEY = "<%= @private_key %>"
 
 EMAIL_BACKEND = "<%= @email['backend'] %>"
 
-SERVER_EMAIL = "<%= @email['user'] %>"
+SERVER_EMAIL = "<%= @email['from'] || @email['user'] %>"
 EMAIL_HOST = "<%= @email['host'] %>"
 EMAIL_HOST_PASSWORD = "<%= @email['password'] %>"
 EMAIL_HOST_USER = "<%= @email['user'] %>"


### PR DESCRIPTION
I felt this could be a helpful addition to the email configuration of this cookbook to allow specifying a from user and then maintain backwards compatibility through falling back to `user`
