### PR TITLE
fix defaulting of hosts for enabled buffers

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -130,8 +130,8 @@ default["sentry"]["servers"] = [{
 
 default["sentry"]["settings"]["redis"]["hosts"] = {
   "0" => {
-    "HOST" => "127.0.0.1",
-    "PORT" => 6379
+    "host" => "127.0.0.1",
+    "port" => 6379
   }}
 
 

--- a/templates/default/sentry/sentry.conf.erb
+++ b/templates/default/sentry/sentry.conf.erb
@@ -104,7 +104,7 @@ SENTRY_TSDB_OPTIONS = {
 <% if @use_queue and @redis['hosts'] %>
 REDIS_DB = SENTRY_REDIS_OPTIONS['hosts'].keys()[0]
 REDIS_DB_CONF = SENTRY_REDIS_OPTIONS['hosts'][REDIS_DB]
-BROKER_URL = "redis://{0}:{1}/{2}".format(REDIS_DB_CONF['HOST'], REDIS_DB_CONF['PORT'], REDIS_DB)
+BROKER_URL = "redis://{0}:{1}/{2}".format(REDIS_DB_CONF['host'], REDIS_DB_CONF['port'], REDIS_DB)
 CELERY_ALWAYS_EAGER = False
 CELERYBEAT_SCHEDULER = "djcelery.schedulers.DatabaseScheduler"
 


### PR DESCRIPTION
kwargs are used to configure the buffers and it expects key words host and port not HOST and PORT